### PR TITLE
Fix bug: Default value for validation type

### DIFF
--- a/src/Components/FormCreation/CardComponents/TextQuestion.tsx
+++ b/src/Components/FormCreation/CardComponents/TextQuestion.tsx
@@ -37,7 +37,9 @@ function TextQuestion({
   };
 
   const [validationType, setValidationType] = useState(
-    initialValidation?.type.toLowerCase() as string
+    initialValidation?.type
+      ? (initialValidation?.type.toLowerCase() as string)
+      : "word"
   );
   const [validationLimit, setValidationLimit] = useState(
     (initialValidation?.min as number) !== 0 ? "least" : "most"


### PR DESCRIPTION
Noticed a quick bug, no default value for validation type.

So, if a user opens validation and doesn't change the validation type, it saves without a type.